### PR TITLE
feat(reinforce-cartpole): republish with Weights & Biases tracking

### DIFF
--- a/notebooks/notebook-database.yml
+++ b/notebooks/notebook-database.yml
@@ -447,5 +447,5 @@ notebooks:
   code_cells: 4
   environment: torch.dev.gpu
   description: REINFORCE policy gradient on CartPole-v1 with learning-curve SVG
-  last_executed: 2026-04-19
-  duration_seconds: 22.2
+    last_executed: 2026-04-20
+    duration_seconds: 21.9

--- a/notebooks/reinforcement-learning/policy-based-algorithms/reinforce/reinforce-cartpole/images/learning-curve.svg
+++ b/notebooks/reinforcement-learning/policy-based-algorithms/reinforce/reinforce-cartpole/images/learning-curve.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-04-19T16:26:00.243386</dc:date>
+    <dc:date>2026-04-20T16:24:01.350393</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 76.889716 277.478125 
 L 76.889716 22.318125 
-" clip-path="url(#p6fec3afcd5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p180559f1f8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m2c786a281a" d="M 0 0 
+       <path id="m915003793e" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2c786a281a" x="76.889716" y="277.478125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m915003793e" x="76.889716" y="277.478125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -88,11 +88,11 @@ z
      <g id="line2d_3">
       <path d="M 176.970288 277.478125 
 L 176.970288 22.318125 
-" clip-path="url(#p6fec3afcd5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p180559f1f8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m2c786a281a" x="176.970288" y="277.478125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m915003793e" x="176.970288" y="277.478125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -134,11 +134,11 @@ z
      <g id="line2d_5">
       <path d="M 277.050859 277.478125 
 L 277.050859 22.318125 
-" clip-path="url(#p6fec3afcd5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p180559f1f8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m2c786a281a" x="277.050859" y="277.478125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m915003793e" x="277.050859" y="277.478125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -170,11 +170,11 @@ z
      <g id="line2d_7">
       <path d="M 377.131431 277.478125 
 L 377.131431 22.318125 
-" clip-path="url(#p6fec3afcd5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p180559f1f8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m2c786a281a" x="377.131431" y="277.478125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m915003793e" x="377.131431" y="277.478125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -190,11 +190,11 @@ L 377.131431 22.318125
      <g id="line2d_9">
       <path d="M 477.212002 277.478125 
 L 477.212002 22.318125 
-" clip-path="url(#p6fec3afcd5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p180559f1f8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m2c786a281a" x="477.212002" y="277.478125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m915003793e" x="477.212002" y="277.478125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -236,11 +236,11 @@ z
      <g id="line2d_11">
       <path d="M 577.292574 277.478125 
 L 577.292574 22.318125 
-" clip-path="url(#p6fec3afcd5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p180559f1f8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m2c786a281a" x="577.292574" y="277.478125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m915003793e" x="577.292574" y="277.478125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -256,11 +256,11 @@ L 577.292574 22.318125
      <g id="line2d_13">
       <path d="M 677.373146 277.478125 
 L 677.373146 22.318125 
-" clip-path="url(#p6fec3afcd5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p180559f1f8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m2c786a281a" x="677.373146" y="277.478125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m915003793e" x="677.373146" y="277.478125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -468,16 +468,16 @@ z
      <g id="line2d_15">
       <path d="M 46.965625 271.097939 
 L 705.295625 271.097939 
-" clip-path="url(#p6fec3afcd5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p180559f1f8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mb5b560e260" d="M 0 0 
+       <path id="m45d32be6cf" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb5b560e260" x="46.965625" y="271.097939" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m45d32be6cf" x="46.965625" y="271.097939" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -491,11 +491,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 46.965625 223.661613 
 L 705.295625 223.661613 
-" clip-path="url(#p6fec3afcd5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p180559f1f8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mb5b560e260" x="46.965625" y="223.661613" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m45d32be6cf" x="46.965625" y="223.661613" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -511,11 +511,11 @@ L 705.295625 223.661613
      <g id="line2d_19">
       <path d="M 46.965625 176.225286 
 L 705.295625 176.225286 
-" clip-path="url(#p6fec3afcd5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p180559f1f8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mb5b560e260" x="46.965625" y="176.225286" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m45d32be6cf" x="46.965625" y="176.225286" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -531,11 +531,11 @@ L 705.295625 176.225286
      <g id="line2d_21">
       <path d="M 46.965625 128.78896 
 L 705.295625 128.78896 
-" clip-path="url(#p6fec3afcd5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p180559f1f8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mb5b560e260" x="46.965625" y="128.78896" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m45d32be6cf" x="46.965625" y="128.78896" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -551,11 +551,11 @@ L 705.295625 128.78896
      <g id="line2d_23">
       <path d="M 46.965625 81.352633 
 L 705.295625 81.352633 
-" clip-path="url(#p6fec3afcd5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p180559f1f8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mb5b560e260" x="46.965625" y="81.352633" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m45d32be6cf" x="46.965625" y="81.352633" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -592,11 +592,11 @@ z
      <g id="line2d_25">
       <path d="M 46.965625 33.916307 
 L 705.295625 33.916307 
-" clip-path="url(#p6fec3afcd5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p180559f1f8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mb5b560e260" x="46.965625" y="33.916307" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m45d32be6cf" x="46.965625" y="33.916307" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -980,7 +980,7 @@ L 671.368311 33.916307
 L 673.369923 81.352633 
 L 675.371534 122.622237 
 L 675.371534 122.622237 
-" clip-path="url(#p6fec3afcd5)" style="fill: none; stroke: #2563eb; stroke-opacity: 0.35; stroke-width: 1.5; stroke-linecap: square"/>
+" clip-path="url(#p180559f1f8)" style="fill: none; stroke: #2563eb; stroke-opacity: 0.35; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="line2d_28">
     <path d="M 124.92839 261.022463 
@@ -1209,12 +1209,12 @@ L 671.368311 95.716353
 L 673.369923 89.208089 
 L 675.371534 84.995743 
 L 675.371534 84.995743 
-" clip-path="url(#p6fec3afcd5)" style="fill: none; stroke: #0f172a; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p180559f1f8)" style="fill: none; stroke: #0f172a; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_29">
     <path d="M 46.965625 45.775388 
 L 705.295625 45.775388 
-" clip-path="url(#p6fec3afcd5)" style="fill: none; stroke-dasharray: 3.7,1.6; stroke-dashoffset: 0; stroke: #059669"/>
+" clip-path="url(#p180559f1f8)" style="fill: none; stroke-dasharray: 3.7,1.6; stroke-dashoffset: 0; stroke: #059669"/>
    </g>
    <g id="patch_3">
     <path d="M 46.965625 277.478125 
@@ -1699,7 +1699,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p6fec3afcd5">
+  <clipPath id="p180559f1f8">
    <rect x="46.965625" y="22.318125" width="658.33" height="255.16"/>
   </clipPath>
  </defs>

--- a/notebooks/reinforcement-learning/policy-based-algorithms/reinforce/reinforce-cartpole/reinforce-cartpole.ipynb
+++ b/notebooks/reinforcement-learning/policy-based-algorithms/reinforce/reinforce-cartpole/reinforce-cartpole.ipynb
@@ -2,64 +2,113 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "87c27996",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003698,
+     "end_time": "2026-04-20T16:17:07.897628",
+     "exception": false,
+     "start_time": "2026-04-20T16:17:07.893930",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "# REINFORCE on CartPole-v1\n",
-    "\n",
-    "Runnable implementation of the REINFORCE algorithm from the [policy-gradient lecture](/aiml-common/lectures/reinforcement-learning/policy-based-algorithms/reinforce). The agent learns a stochastic policy $\\pi_\\theta(a \\mid s)$ over the two CartPole actions, using Monte Carlo returns $G_t$ as the unbiased estimator of $Q^{\\pi_\\theta}(s, a)$ in the policy gradient\n",
+    "Runnable implementation of the REINFORCE algorithm from the [policy-gradient lecture](/aiml-common/lectures/reinforcement-learning/policy-based-algorithms/reinforce). The agent learns a stochastic policy $\\pi_\\theta(a \\mid s)$ over the two CartPole actions, using Monte Carlo returns $G_t$ as an unbiased estimator of the action-value $Q^\\pi(s, a)$ under the current policy inside the policy gradient\n",
     "\n",
     "$$\n",
-    "\\nabla_\\theta J(\\pi_\\theta) = \\mathbb{E}_{\\pi_\\theta}\\bigl[\\nabla_\\theta \\log \\pi_\\theta(a \\mid s)\\, G_t\\bigr].\n",
+    "\\nabla_\\theta J(\\pi_\\theta) = \\mathbb{E}_\\pi\\left[\\nabla_\\theta \\log \\pi_\\theta(a \\mid s)\\, G_t\\right].\n",
     "$$\n",
     "\n",
     "CartPole-v1 is considered solved at an average episode return of $475$ (max is $500$)."
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "cell_type": "markdown",
+   "id": "3d6c931f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001653,
+     "end_time": "2026-04-20T16:17:07.902181",
+     "exception": false,
+     "start_time": "2026-04-20T16:17:07.900528",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "%matplotlib inline\n",
+    "## The CartPole-v1 problem\n",
     "\n",
-    "from pathlib import Path\n",
-    "import os\n",
+    "CartPole is a classical control benchmark introduced by Barto, Sutton, and Anderson (1983) and now the \"hello world\" of deep RL. A pole is hinged on a cart that slides along a frictionless track. The agent chooses, at every timestep, whether to push the cart **left** or **right**; gravity and the cart's motion together determine how the pole tilts. The agent's task is to keep the pole upright for as long as possible.\n",
     "\n",
-    "from torch.distributions import Categorical\n",
-    "import gymnasium as gym\n",
-    "import numpy as np\n",
-    "import torch\n",
-    "import torch.nn as nn\n",
-    "import torch.optim as optim\n",
-    "import matplotlib.pyplot as plt\n",
+    "![Gymnasium CartPole-v1 render — a black cart on a horizontal track with a light-brown pole standing straight up](images/cartpole.png)\n",
     "\n",
-    "torch.manual_seed(0)\n",
-    "np.random.seed(0)\n",
+    "*The Gymnasium `CartPole-v1` render: black cart, vertical pole, horizontal track. The environment emits one such frame per step.*\n",
     "\n",
-    "gamma = 0.99\n",
-    "num_episodes = 300\n",
+    "### Observation, action, reward\n",
     "\n",
+    "| | | |\n",
+    "|---|---|---|\n",
+    "| **Observation** (state $s$) | 4-D continuous | $[x,\\, \\dot x,\\, \\theta,\\, \\dot\\theta]$ — cart position, cart velocity, pole angle (radians), pole angular velocity |\n",
+    "| **Action** (action $a$) | 2 discrete | $0$ = push left, $1$ = push right (no \"do nothing\" action) |\n",
+    "| **Reward** | $+1$ | granted for every timestep the pole stays up (including the terminal step) |\n",
+    "| **Episode length** | $\\leq 500$ | hard cap in `v1` (was $200$ in `v0`) |\n",
     "\n",
-    "_NB_NAME = \"reinforce-cartpole.ipynb\"\n",
+    "### Termination\n",
     "\n",
+    "An episode ends as soon as any of the following occurs:\n",
     "\n",
-    "def _notebook_dir() -> Path:\n",
-    "    pm_input = os.environ.get(\"PM_INPUT_PATH\")\n",
-    "    if pm_input and Path(pm_input).is_file():\n",
-    "        return Path(pm_input).resolve().parent\n",
-    "    for candidate in Path.cwd().rglob(_NB_NAME):\n",
-    "        return candidate.resolve().parent\n",
-    "    return Path.cwd()\n",
+    "- **pole fell too far** — $\\lvert\\theta\\rvert > 12°$ ($\\approx 0.2095$ rad)\n",
+    "- **cart left the track** — $\\lvert x \\rvert > 2.4$\n",
+    "- **time-limit reached** — $t = 500$ (truncation, not failure)\n",
     "\n",
+    "Because each step grants reward $1$, the **return** for an episode equals its length. The best possible return is $500$.\n",
     "\n",
-    "IMAGES_DIR = _notebook_dir() / \"images\"\n",
-    "IMAGES_DIR.mkdir(parents=True, exist_ok=True)"
+    "### \"Solved\" threshold\n",
+    "\n",
+    "Gymnasium considers CartPole-v1 solved when the agent averages **$\\geq 475$ return over $100$ consecutive episodes**. Our training loop below reports a simpler per-episode check (`total_reward > 475`) as a quick indicator of progress — the true solved criterion is a sliding average.\n",
+    "\n",
+    "### Why it's a good benchmark for REINFORCE\n",
+    "\n",
+    "The state space is small and continuous, the action set is tiny, and the reward signal is dense (every step contributes), so a stochastic policy can learn from just a few hundred episodes without a value baseline. This makes CartPole useful for *seeing* a policy-gradient signal at all — and also for exposing its limitations: the variance and stability issues discussed on the [parent lecture page](/aiml-common/lectures/reinforcement-learning/policy-based-algorithms/reinforce#why-the-learning-curve-is-not-monotonic) show up clearly here, even though the environment itself is \"easy.\""
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9bf276c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-20T16:17:07.908902Z",
+     "iopub.status.busy": "2026-04-20T16:17:07.908719Z",
+     "iopub.status.idle": "2026-04-20T16:17:10.997899Z",
+     "shell.execute_reply": "2026-04-20T16:17:10.997301Z"
+    },
+    "papermill": {
+     "duration": 3.09474,
+     "end_time": "2026-04-20T16:17:10.998264",
+     "exception": false,
+     "start_time": "2026-04-20T16:17:07.903524",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": "%matplotlib inline\n\nfrom __future__ import annotations\nfrom pathlib import Path\nimport logging\nimport os\n\n# Silence wandb's verbose init banner so only a single one-line summary\n# reaches the rendered MDX. Must be set *before* `import wandb`.\nos.environ.setdefault(\"WANDB_SILENT\", \"true\")\nos.environ.setdefault(\"WANDB_CONSOLE\", \"off\")\n\nfrom torch.distributions import Categorical\nimport gymnasium as gym\nimport numpy as np\nimport torch\nimport torch.nn as nn\nimport torch.optim as optim\nimport matplotlib.pyplot as plt\n\ntorch.manual_seed(0)\nnp.random.seed(0)\n\ngamma = 0.99\nnum_episodes = 300\nlearning_rate = 0.01\nhidden_dim = 64\n\n\n_NB_NAME = \"reinforce-cartpole.ipynb\"\n\n\ndef _notebook_dir() -> Path:\n    pm_input = os.environ.get(\"PM_INPUT_PATH\")\n    if pm_input and Path(pm_input).is_file():\n        return Path(pm_input).resolve().parent\n    for candidate in Path.cwd().rglob(_NB_NAME):\n        return candidate.resolve().parent\n    return Path.cwd()\n\n\nIMAGES_DIR = _notebook_dir() / \"images\"\nIMAGES_DIR.mkdir(parents=True, exist_ok=True)\n\n\n# --- Weights & Biases experiment tracking ------------------------------------\n# All runs land in the shared `pantelis/eng-ai-agents` project so training\n# curves and the harness's system telemetry are observable side-by-side (same\n# project the `notebooks/scripts/wandb_utils.py` harness uses). When the\n# harness has already started a run in the parent process and exported\n# `WANDB_RUN_ID` to the kernel, wandb will *attach* to that run via\n# `resume=\"allow\"`; otherwise a fresh run named `reinforce-cartpole` is\n# created inside the same project.\n#\n# Override the project/entity with WANDB_PROJECT / WANDB_ENTITY, or set\n# WANDB_MODE=disabled to run fully offline.\n_use_wandb = False\ntry:\n    logging.getLogger(\"wandb\").setLevel(logging.WARNING)\n    import wandb\n\n    if wandb.run is None:\n        wandb.init(\n            project=os.environ.get(\"WANDB_PROJECT\", \"eng-ai-agents\"),\n            entity=os.environ.get(\"WANDB_ENTITY\", \"pantelis\"),\n            name=\"reinforce-cartpole\",\n            group=\"reinforcement-learning\",\n            tags=[\"reinforcement-learning\", \"policy-gradient\", \"cartpole\"],\n            config={\n                \"algorithm\": \"REINFORCE\",\n                \"environment\": \"CartPole-v1\",\n                \"gamma\": gamma,\n                \"num_episodes\": num_episodes,\n                \"learning_rate\": learning_rate,\n                \"hidden_dim\": hidden_dim,\n            },\n            mode=os.environ.get(\"WANDB_MODE\", \"online\"),\n            resume=\"allow\",\n            reinit=\"finish_previous\",\n        )\n    # Declare episode as the x-axis for every training metric so wandb's\n    # auto-generated line charts plot against episode, not an internal step.\n    wandb.define_metric(\"episode\")\n    for metric in (\"loss\", \"return\", \"return_mean_50\"):\n        wandb.define_metric(metric, step_metric=\"episode\")\n    _use_wandb = wandb.run.settings.mode != \"disabled\"\n    if _use_wandb:\n        print(f\"wandb dashboard: {wandb.run.url}\")\n    else:\n        print(\"wandb running in disabled mode (no credentials) — training without metric streaming\")\nexcept Exception as exc:\n    print(f\"wandb init failed ({exc}); training will run without metric streaming\")\n\n\ndef save_svg(fig, name: str) -> Path:\n    \"\"\"Save `fig` to images/<name>.svg and close it.\n\n    Closing suppresses any inline image output so the generated MDX does not\n    receive an auto-inserted <Frame><img/></Frame> block from the converter.\n    Zoomable SVGs are referenced explicitly from the following markdown cell.\n    \"\"\"\n    path = IMAGES_DIR / f\"{name}.svg\"\n    fig.savefig(path, format=\"svg\", bbox_inches=\"tight\")\n    plt.close(fig)\n    return path"
+  },
+  {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "df482663",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001619,
+     "end_time": "2026-04-20T16:17:11.001765",
+     "exception": false,
+     "start_time": "2026-04-20T16:17:11.000146",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Policy network and REINFORCE update\n",
     "\n",
@@ -69,7 +118,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "id": "d172847b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-20T16:17:11.005409Z",
+     "iopub.status.busy": "2026-04-20T16:17:11.005260Z",
+     "iopub.status.idle": "2026-04-20T16:17:11.010203Z",
+     "shell.execute_reply": "2026-04-20T16:17:11.009675Z"
+    },
+    "papermill": {
+     "duration": 0.007326,
+     "end_time": "2026-04-20T16:17:11.010589",
+     "exception": false,
+     "start_time": "2026-04-20T16:17:11.003263",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "class Pi(nn.Module):\n",
@@ -117,26 +182,52 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "38dce008",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001892,
+     "end_time": "2026-04-20T16:17:11.014295",
+     "exception": false,
+     "start_time": "2026-04-20T16:17:11.012403",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Training loop\n",
     "\n",
-    "CartPole is a very forgiving environment; a fresh, untuned REINFORCE agent typically reaches the 475-return solved threshold within a few hundred episodes. Rewards are stored per episode so we can plot the learning curve."
+    "CartPole is a very forgiving environment; a fresh, untuned REINFORCE agent typically reaches the 475-return solved threshold within a few hundred episodes. Per-episode **loss**, **return**, and a running **50-episode mean return** are streamed to Weights & Biases (free at [wandb.ai](https://wandb.ai/)) rather than printed to the notebook — this keeps the rendered page short and the metrics interactive. If wandb is not configured, training still runs but metrics are only summarized at the end."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "id": "f8c23970",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-20T16:17:11.018276Z",
+     "iopub.status.busy": "2026-04-20T16:17:11.018172Z",
+     "iopub.status.idle": "2026-04-20T16:17:27.575991Z",
+     "shell.execute_reply": "2026-04-20T16:17:27.575460Z"
+    },
+    "papermill": {
+     "duration": 16.560542,
+     "end_time": "2026-04-20T16:17:27.576583",
+     "exception": false,
+     "start_time": "2026-04-20T16:17:11.016041",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "env = gym.make(\"CartPole-v1\")\n",
     "in_dim = env.observation_space.shape[0]  # 4\n",
     "out_dim = env.action_space.n              # 2\n",
     "pi = Pi(in_dim, out_dim)\n",
-    "optimizer = optim.Adam(pi.parameters(), lr=0.01)\n",
+    "optimizer = optim.Adam(pi.parameters(), lr=learning_rate)\n",
     "\n",
-    "episode_returns = []\n",
+    "episode_returns: list[float] = []\n",
     "first_solved = None\n",
     "\n",
     "for epi in range(num_episodes):\n",
@@ -153,17 +244,44 @@
     "    if first_solved is None and total_reward > 475.0:\n",
     "        first_solved = epi\n",
     "    pi.onpolicy_reset()\n",
-    "    if epi % 25 == 0 or epi == num_episodes - 1:\n",
-    "        print(f\"episode {epi:>3d}  loss={loss:>9.2f}  return={total_reward:>6.1f}\")\n",
+    "\n",
+    "    if _use_wandb:\n",
+    "        window = episode_returns[-50:]\n",
+    "        wandb.log({\n",
+    "            \"episode\": epi,\n",
+    "            \"loss\": loss,\n",
+    "            \"return\": total_reward,\n",
+    "            \"return_mean_50\": float(np.mean(window)),\n",
+    "        })\n",
     "\n",
     "env.close()\n",
-    "print(f\"\\nFirst episode with return > 475: {first_solved}\")\n",
-    "print(f\"Mean return over last 50 episodes: {np.mean(episode_returns[-50:]):.1f}\")"
+    "\n",
+    "mean_last_50 = float(np.mean(episode_returns[-50:]))\n",
+    "peak_return = float(max(episode_returns))\n",
+    "print(f\"Episodes run: {num_episodes}\")\n",
+    "print(f\"First episode with return > 475: {first_solved}\")\n",
+    "print(f\"Peak return: {peak_return:.0f}\")\n",
+    "print(f\"Mean return over last 50 episodes: {mean_last_50:.1f}\")\n",
+    "\n",
+    "if _use_wandb:\n",
+    "    wandb.summary[\"first_solved_episode\"] = first_solved\n",
+    "    wandb.summary[\"peak_return\"] = peak_return\n",
+    "    wandb.summary[\"mean_return_last_50\"] = mean_last_50"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "6ec39920",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001573,
+     "end_time": "2026-04-20T16:17:27.581154",
+     "exception": false,
+     "start_time": "2026-04-20T16:17:27.579581",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Learning curve\n",
     "\n",
@@ -173,7 +291,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "id": "ad9f8695",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-20T16:17:27.585118Z",
+     "iopub.status.busy": "2026-04-20T16:17:27.584889Z",
+     "iopub.status.idle": "2026-04-20T16:17:27.665434Z",
+     "shell.execute_reply": "2026-04-20T16:17:27.664861Z"
+    },
+    "papermill": {
+     "duration": 0.08345,
+     "end_time": "2026-04-20T16:17:27.666165",
+     "exception": false,
+     "start_time": "2026-04-20T16:17:27.582715",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "returns = np.array(episode_returns, dtype=np.float32)\n",
@@ -200,17 +334,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "14cd220a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001644,
+     "end_time": "2026-04-20T16:17:27.669623",
+     "exception": false,
+     "start_time": "2026-04-20T16:17:27.667979",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "![REINFORCE learning curve on CartPole-v1 — per-episode returns and a 25-episode moving average rising toward the 475 solved threshold](images/learning-curve.svg)\n",
     "\n",
-    "*Learning curve — per-episode return and moving average.*\n",
-    "\n",
-    "## Where to go next\n",
-    "\n",
-    "- **Reduce variance** by subtracting a state-dependent baseline $b(s)$ from the return. A common choice is $b(s) = v_\\pi(s)$ estimated by a separate network; this produces the advantage $A(s, a) = G_t - v_\\pi(s)$ and leads to actor-critic methods, PPO, and GRPO.\n",
-    "- **Try a harder environment** like LunarLander-v2; REINFORCE still works but convergence gets much noisier, motivating the baseline.\n",
-    "- Back to the lecture: [REINFORCE](/aiml-common/lectures/reinforcement-learning/policy-based-algorithms/reinforce)."
+    "*Learning curve — per-episode return and moving average. The curve is not monotonic; see the [parent lecture page](/aiml-common/lectures/reinforcement-learning/policy-based-algorithms/reinforce#why-the-learning-curve-is-not-monotonic) for why, and the variance-reduction discussion that follows.*"
    ]
   }
  ],
@@ -221,8 +359,28 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.13"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 21.456053,
+   "end_time": "2026-04-20T16:17:28.589799",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "notebooks/reinforcement-learning/policy-based-algorithms/reinforce/reinforce-cartpole/reinforce-cartpole.ipynb",
+   "output_path": "notebooks/reinforcement-learning/policy-based-algorithms/reinforce/reinforce-cartpole/reinforce-cartpole-executed.ipynb",
+   "parameters": {},
+   "start_time": "2026-04-20T16:17:07.133746",
+   "version": "2.6.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Republish the REINFORCE CartPole notebook after upstream [aegean-ai/aiml-common#17](https://github.com/aegean-ai/aiml-common/pull/17), which adds:
- Up-front CartPole problem description (observation/action/reward/termination, illustrated with the Gymnasium render).
- Live wandb metric streaming — per-episode loss, return, 50-episode mean return all land in `pantelis/eng-ai-agents` alongside the harness's system telemetry.
- Silenced wandb init banner so the rendered MDX is 3 output blocks (down from 12).

## Test plan

- [ ] `make execute-notebook NOTEBOOK=reinforcement-learning/policy-based-algorithms/reinforce/reinforce-cartpole/reinforce-cartpole.ipynb` succeeds.
- [ ] Executed run appears in https://wandb.ai/pantelis/eng-ai-agents with `loss`, `return`, `return_mean_50` charts plotted against `episode`.

---
AI-assisted: drafted with Claude Code (Opus 4.7).