### PR TITLE
docs: publish CTR logistic-regression assignment

### DIFF
--- a/notebooks/assignments/topics/logistic-regression/ctr-logreg-sgd/ctr_logreg_sgd_assignment.ipynb
+++ b/notebooks/assignments/topics/logistic-regression/ctr-logreg-sgd/ctr_logreg_sgd_assignment.ipynb
@@ -1,0 +1,449 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Predicting ad Click-Through Rate with logistic regression (SGD)\n",
+    "\n",
+    "You are interviewing with an ad team. The task: predict the **click-through rate\n",
+    "(CTR)** of an ad from categorical context (site, app, device, position, hour). The\n",
+    "classic benchmark is the [Avazu CTR dataset](https://www.kaggle.com/competitions/avazu-ctr-prediction/data);\n",
+    "the markdown below shows how to plug it in. So the notebook runs anywhere, it\n",
+    "also ships a synthetic generator that mirrors the Avazu schema (high-cardinality\n",
+    "IDs and a realistic ~17% click rate).\n",
+    "\n",
+    "**You will implement**\n",
+    "- the **hashing trick** for high-cardinality categorical features,\n",
+    "- the log-loss gradient (derived by hand) and **logistic regression trained with SGD**,\n",
+    "- imbalance-aware evaluation: log-loss, the **precision-recall** curve, average precision,\n",
+    "\n",
+    "**and then investigate**\n",
+    "- how the hash dimension trades memory against collisions, and\n",
+    "- whether your predicted probabilities are **calibrated** (which ad auctions require).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import hashlib\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "rng = np.random.default_rng(0)\n",
+    "\n",
+    "\n",
+    "def sigmoid(z):\n",
+    "    return 1.0 / (1.0 + np.exp(-np.clip(z, -30, 30)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The data\n",
+    "\n",
+    "Real CTR features are mostly high-cardinality categoricals (IDs with thousands to millions of values) and the positive class is rare. The generator below produces data with those properties; the commented lines show how to load the real Avazu CSV instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Columns mirror a slimmed-down Avazu schema. The first few are high-cardinality\n",
+    "# (like site_id / app_id / device_id); the rest are low-cardinality context.\n",
+    "CARD = {\n",
+    "    \"site_id\": 1500, \"app_id\": 1200, \"device_id\": 6000,\n",
+    "    \"site_category\": 22, \"app_category\": 18,\n",
+    "    \"device_type\": 5, \"banner_pos\": 4, \"hour\": 24,\n",
+    "}\n",
+    "CAT_COLS = list(CARD)\n",
+    "\n",
+    "\n",
+    "def _calibrate_bias(logit, target):\n",
+    "    lo, hi = -20.0, 20.0\n",
+    "    for _ in range(60):\n",
+    "        mid = 0.5 * (lo + hi)\n",
+    "        if sigmoid(logit + mid).mean() < target:\n",
+    "            lo = mid\n",
+    "        else:\n",
+    "            hi = mid\n",
+    "    return 0.5 * (lo + hi)\n",
+    "\n",
+    "\n",
+    "def make_ctr_data(n=30000, target_ctr=0.17, seed=0):\n",
+    "    \"\"\"Synthetic click-through data that mimics the Avazu schema.\n",
+    "\n",
+    "    Click probability is driven by per-value latent weights plus one\n",
+    "    category interaction, then the intercept is calibrated so the overall\n",
+    "    click rate is ~target_ctr (a realistically imbalanced problem).\n",
+    "    Returns a DataFrame of string categorical columns plus a 0/1 `click`.\n",
+    "    \"\"\"\n",
+    "    g = np.random.default_rng(seed)\n",
+    "    # a few columns carry more signal than others\n",
+    "    scale = {\"site_id\": 0.5, \"app_id\": 0.5, \"device_id\": 0.2, \"site_category\": 0.8,\n",
+    "             \"app_category\": 0.7, \"device_type\": 0.4, \"banner_pos\": 0.6, \"hour\": 0.3}\n",
+    "    latent = {c: g.normal(0, scale[c], size=CARD[c]) for c in CAT_COLS}\n",
+    "    vals = {c: g.integers(0, CARD[c], size=n) for c in CAT_COLS}\n",
+    "\n",
+    "    logit = np.zeros(n)\n",
+    "    for c in CAT_COLS:\n",
+    "        logit += latent[c][vals[c]]\n",
+    "    # interaction: certain (site_category, device_type) pairs click more\n",
+    "    inter = g.normal(0, 0.7, size=(CARD[\"site_category\"], CARD[\"device_type\"]))\n",
+    "    logit += inter[vals[\"site_category\"], vals[\"device_type\"]]\n",
+    "\n",
+    "    logit += _calibrate_bias(logit, target_ctr)\n",
+    "    click = (g.random(n) < sigmoid(logit)).astype(int)\n",
+    "    df = pd.DataFrame({c: [f\"{c}_{v}\" for v in vals[c]] for c in CAT_COLS})\n",
+    "    df[\"click\"] = click\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "df = make_ctr_data(n=30000, target_ctr=0.17, seed=0)\n",
+    "print(\"rows:\", len(df), \"| click rate:\", round(df['click'].mean(), 3))\n",
+    "print(\"unique device_id values:\", df['device_id'].nunique())\n",
+    "df.head()\n",
+    "\n",
+    "# ---------------------------------------------------------------------------\n",
+    "# To use the REAL data instead, accept the Avazu competition on Kaggle, then:\n",
+    "#     df = pd.read_csv(\"train.gz\", nrows=300_000)\n",
+    "#     df = df.rename(columns={\"click\": \"click\"})  # already named `click`\n",
+    "# Keep CAT_COLS to the categorical columns you want to hash; everything below\n",
+    "# works unchanged on the real frame.\n",
+    "# ---------------------------------------------------------------------------"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def train_test_split(df, test_size=0.3, seed=123):\n",
+    "    idx = np.arange(len(df))\n",
+    "    np.random.default_rng(seed).shuffle(idx)\n",
+    "    n_test = int(round(test_size * len(df)))\n",
+    "    return df.iloc[idx[n_test:]].reset_index(drop=True), df.iloc[idx[:n_test]].reset_index(drop=True)\n",
+    "\n",
+    "\n",
+    "train_df, test_df = train_test_split(df)\n",
+    "y_train = train_df[\"click\"].to_numpy()\n",
+    "y_test = test_df[\"click\"].to_numpy()\n",
+    "len(train_df), len(test_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 1 - The hashing trick\n",
+    "\n",
+    "Map each `column=value` token to one of `D` buckets with a stable hash. This is how CTR models handle features with huge, open-ended vocabularies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def hash_row(row, cols, D):\n",
+    "    \"\"\"Return the list of active bucket indices for one row (the hashing trick).\n",
+    "\n",
+    "    For each column build a stable token like \"site_id=site_id_42\", hash it to\n",
+    "    an integer in [0, D), and collect those indices. Use a deterministic hash\n",
+    "    (hashlib), NOT Python's built-in hash() which is salted per process.\n",
+    "    \"\"\"\n",
+    "    # TODO: hash each \"col=value\" token into [0, D) and return the index list.\n",
+    "    raise NotImplementedError\n",
+    "\n",
+    "\n",
+    "def build_index_matrix(frame, cols, D):\n",
+    "    \"\"\"Apply hash_row to every row -> int array of shape (n, len(cols)).\"\"\"\n",
+    "    return np.array([hash_row(r, cols, D) for _, r in frame.iterrows()], dtype=np.int64)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 2 - Derive the gradient\n",
+    "\n",
+    "Write logistic regression for a single example with multi-hot feature vector\n",
+    "$\\mathbf{x}$ (here, ones at the hashed buckets), weights $\\mathbf{w}$, bias $b$:\n",
+    "\n",
+    "$$z = \\mathbf{w}^\\top \\mathbf{x} + b, \\qquad p = \\sigma(z), \\qquad\n",
+    "\\ell = -\\big(y \\log p + (1-y)\\log(1-p)\\big).$$\n",
+    "\n",
+    "Derive $\\dfrac{\\partial \\ell}{\\partial \\mathbf{w}}$ and $\\dfrac{\\partial \\ell}{\\partial b}$,\n",
+    "and explain what the update looks like for the **hashed** representation where only a\n",
+    "handful of entries of $\\mathbf{x}$ are nonzero. Write your derivation in the cell below.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "_Your derivation here._\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 3 - Logistic regression with SGD\n",
+    "\n",
+    "Implement the training loop from the gradient you derived. Update only the active (hashed) weights."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def train_logreg_sgd(X_idx, y, D, lr=0.1, epochs=3, l2=1e-6, seed=0):\n",
+    "    \"\"\"From-scratch SGD logistic regression over hashed features.\n",
+    "\n",
+    "    Maintain a weight vector w of length D and a bias b. For each example the\n",
+    "    logit is b + sum of w over the row's active buckets. Use the gradient you\n",
+    "    derived in Task 2 to update ONLY the active weights (plus the bias), with\n",
+    "    optional L2 shrinkage. Return (w, b).\n",
+    "    \"\"\"\n",
+    "    w = np.zeros(D)\n",
+    "    b = 0.0\n",
+    "    # TODO: loop over epochs and shuffled examples; apply the SGD update.\n",
+    "    raise NotImplementedError\n",
+    "\n",
+    "\n",
+    "def predict_proba(X_idx, w, b):\n",
+    "    \"\"\"Vectorized probabilities: sigmoid(b + sum of active weights).\"\"\"\n",
+    "    return sigmoid(b + w[X_idx].sum(axis=1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 4 - Evaluation under class imbalance\n",
+    "\n",
+    "With ~17% positives, accuracy is meaningless. Implement log-loss and the precision-recall curve, then evaluate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def log_loss(y, p, eps=1e-12):\n",
+    "    \"\"\"Mean binary cross-entropy.\"\"\"\n",
+    "    # TODO\n",
+    "    raise NotImplementedError\n",
+    "\n",
+    "\n",
+    "def pr_curve(y, p):\n",
+    "    \"\"\"Return (recall, precision) arrays by sweeping the threshold from high\n",
+    "    score to low (sort by descending p and accumulate TP/FP).\"\"\"\n",
+    "    # TODO\n",
+    "    raise NotImplementedError\n",
+    "\n",
+    "\n",
+    "def average_precision(y, p):\n",
+    "    \"\"\"Area under the precision-recall curve (integrate precision over recall).\"\"\"\n",
+    "    # TODO\n",
+    "    raise NotImplementedError"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "D = 2 ** 18\n",
+    "Xtr = build_index_matrix(train_df, CAT_COLS, D)\n",
+    "Xte = build_index_matrix(test_df, CAT_COLS, D)\n",
+    "w, b = train_logreg_sgd(Xtr, y_train, D, lr=0.1, epochs=3)\n",
+    "\n",
+    "p_te = predict_proba(Xte, w, b)\n",
+    "base_rate = y_train.mean()\n",
+    "print(f\"baseline log-loss (predict the base rate {base_rate:.3f}): \"\n",
+    "      f\"{log_loss(y_test, np.full_like(p_te, base_rate)):.4f}\")\n",
+    "print(f\"model log-loss:    {log_loss(y_test, p_te):.4f}\")\n",
+    "print(f\"model avg precision (PR-AUC): {average_precision(y_test, p_te):.4f}\")\n",
+    "print(f\"positives in test: {y_test.mean():.3f}  (so 'always no-click' has {1-y_test.mean():.3f} accuracy)\")\n",
+    "\n",
+    "rec, prec = pr_curve(y_test, p_te)\n",
+    "plt.figure(figsize=(6, 4.5))\n",
+    "plt.plot(rec, prec, label=f\"model (AP={average_precision(y_test, p_te):.3f})\")\n",
+    "plt.axhline(y_test.mean(), ls=\"--\", c=\"grey\", label=f\"random (={y_test.mean():.2f})\")\n",
+    "plt.xlabel(\"recall\"); plt.ylabel(\"precision\")\n",
+    "plt.title(\"Precision-recall on the test set\"); plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 5 - Does the hash dimension matter?\n",
+    "\n",
+    "The heart of the assignment: sweep `D` and watch collisions trade off against memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Centerpiece: how does the hash dimension D trade memory against collisions?\n",
+    "Ds = [2 ** 8, 2 ** 10, 2 ** 12, 2 ** 14, 2 ** 16, 2 ** 18]\n",
+    "ap_by_D, ll_by_D = [], []\n",
+    "for Dk in Ds:\n",
+    "    # TODO for each Dk:\n",
+    "    #   build train/test index matrices at dimension Dk\n",
+    "    #   train logreg, predict on test\n",
+    "    #   record average_precision and log_loss\n",
+    "    raise NotImplementedError\n",
+    "\n",
+    "for Dk, ap, ll in zip(Ds, ap_by_D, ll_by_D):\n",
+    "    print(f\"D=2^{int(np.log2(Dk)):>2}  AP={ap:.3f}  logloss={ll:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "fig, ax1 = plt.subplots(figsize=(6.5, 4.5))\n",
+    "xs = [int(np.log2(d)) for d in Ds]\n",
+    "ax1.plot(xs, ap_by_D, \"-o\", color=\"tab:blue\")\n",
+    "ax1.set_xlabel(\"hash dimension  (log2 D)\")\n",
+    "ax1.set_ylabel(\"average precision\", color=\"tab:blue\")\n",
+    "ax2 = ax1.twinx()\n",
+    "ax2.plot(xs, ll_by_D, \"-s\", color=\"tab:red\")\n",
+    "ax2.set_ylabel(\"log loss\", color=\"tab:red\")\n",
+    "plt.title(\"Hashing trick: collisions hurt when D is too small\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 6 - Calibration\n",
+    "\n",
+    "A good *ranking* is not enough for ad bidding; the predicted probabilities must mean what they say. Build a reliability curve."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def reliability_curve(y, p, n_bins=10):\n",
+    "    \"\"\"Bin predictions into n_bins equal-width probability bins; return\n",
+    "    (mean_predicted, empirical_rate) per non-empty bin.\"\"\"\n",
+    "    # TODO\n",
+    "    raise NotImplementedError"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "mp, emp = reliability_curve(y_test, p_te, n_bins=10)\n",
+    "plt.figure(figsize=(5.5, 5.5))\n",
+    "plt.plot([0, 1], [0, 1], \"--\", c=\"grey\", label=\"perfectly calibrated\")\n",
+    "plt.plot(mp, emp, \"-o\", label=\"model\")\n",
+    "plt.xlabel(\"mean predicted CTR\"); plt.ylabel(\"empirical CTR\")\n",
+    "plt.title(\"Calibration (reliability) curve\"); plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conceptual questions\n",
+    "\n",
+    "1. The click rate is ~17%. What accuracy does the trivial \"always predict\n",
+    "   no-click\" model get, and why is accuracy the wrong headline metric here?\n",
+    "   Why are log-loss, average precision, and the PR curve more informative?\n",
+    "2. The hashing trick replaces one-hot encoding of high-cardinality IDs. What do\n",
+    "   you gain (memory, handling unseen values at test time) and what do you lose\n",
+    "   (collisions)? From your D sweep, where does shrinking D start to hurt, and why?\n",
+    "3. Restate the gradient you derived and explain why a hashed example updates only\n",
+    "   a handful of weights. Why does that make this model scale to billions of\n",
+    "   features?\n",
+    "4. Read your calibration curve. Are the predicted probabilities calibrated? Why\n",
+    "   does ad ranking/bidding (which multiplies predicted CTR by a bid) *need*\n",
+    "   calibrated probabilities, not just a good ranking?\n",
+    "5. Name one way to handle the class imbalance (class weights, threshold tuning,\n",
+    "   negative downsampling, ...). How would it move the PR curve and the calibration?\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "_Your answers here._\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What to submit\n",
+    "\n",
+    "- This notebook with every `# TODO` completed and run top to bottom (the synthetic\n",
+    "  generator makes it fully reproducible; swap in the real Avazu frame if you want).\n",
+    "- The gradient derivation, the PR curve, the D-sweep figure, and the calibration curve.\n",
+    "- Written answers to the five conceptual questions.\n",
+    "\n",
+    "**Grading (100 pts):** hashing trick (15), gradient derivation (15), SGD logreg\n",
+    "(20), imbalance-aware metrics + PR curve (20), hash-dimension sweep (15),\n",
+    "calibration + answers (15).\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/notebook-database.yml
+++ b/notebooks/notebook-database.yml
@@ -549,3 +549,8 @@ notebooks:
   description: Momentum, Nesterov, RMSProp and Adam from scratch on ravine and saddle landscapes, with a PyTorch coda
   last_executed: 2026-05-31
   duration_seconds: 4.8
+- source: aiml-common/assignments/topics/logistic-regression/ctr-logreg-sgd/ctr_logreg_sgd_assignment.ipynb
+  notebook: assignments/topics/logistic-regression/ctr-logreg-sgd/ctr_logreg_sgd_assignment.ipynb
+  code_cells: 12
+  environment: torch.dev.gpu
+  description: CTR prediction with logistic regression, the hashing trick and SGD


### PR DESCRIPTION
## Why

Publishes the student-facing **Click-Through-Rate** assignment (logistic regression with the **hashing trick** and from-scratch **SGD**, on a self-contained synthetic CTR dataset that mirrors the Avazu schema) so it is available for Docker execution and a Colab badge.

Companion content lives in aiml-common (`assignments/topics/logistic-regression/ctr-logreg-sgd/`). The instructor **solutions** notebook is intentionally **not** published here, per repo policy.

## Note

The notebook is a scaffold with `# TODO`s, so it is registered but not executed (execution would fail by design until a student fills it in).

## AI disclaimer

Prepared with the assistance of an AI agent (Claude Code); a human reviewed it before submission.