### PR TITLE
Publish Explaining CNNs assignment notebook

### DIFF
--- a/notebooks/assignments/topics/cnn-explainers/index.ipynb
+++ b/notebooks/assignments/topics/cnn-explainers/index.ipynb
@@ -1,0 +1,35 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "format:\n",
+    "    html: default\n",
+    "    ipynb: default\n",
+    "jupyter: python3\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Explaining CNNs\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "In this assignment you implement two explainer algorithms for Convolutional Neural Networks (CNNs) and use them to inspect a model you have already trained. An explainer answers a question that accuracy alone cannot: which parts of an input drove this particular prediction? For an image classifier that answer takes the form of a saliency map, and a trustworthy map should highlight the animal rather than the background, a watermark, or some dataset artifact the model latched onto.\n\nWe invite you to watch the following video, which sets the context and walks through the tools you can use.\n\n<iframe width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/Am2EF9CLu-g\" frameBorder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\" allowFullScreen></iframe>\n\nIn the [cats vs dogs](https://huggingface.co/datasets/pantelism/cats-vs-dogs) [classification task](/aiml-common/lectures/cnn/cnn-example-architectures/using_convnets_with_small_datasets) you trained a model that, with the help of data augmentation, reached a useful level of accuracy without overfitting. That trained model is your subject here. You do not retrain it or change its architecture; you attach explainers to it and interpret what they reveal about how it decides.\n\n### The two methods you will implement\n\n**Integrated gradients** ([Sundararajan et al., 2017](https://arxiv.org/abs/1703.01365)) attributes a prediction to individual input pixels. It picks a baseline image (commonly an all-black image, which the model should find uninformative) and integrates the gradient of the class score along the straight-line path from that baseline to the actual input. The result is a per-pixel attribution with two properties that plain input gradients lack: completeness, meaning the attributions sum to the difference in model output between the input and the baseline, and robustness to saturated activations, where a plain gradient would read close to zero even though the feature mattered.\n\n**Grad-CAM** ([Selvaraju et al., 2016](https://arxiv.org/abs/1610.02391)) produces a coarse, class-discriminative heatmap. It takes the feature maps of a convolutional layer, usually the last one, and weights each map by the gradient of the class score flowing into it. Because it works at the resolution of a deep feature map rather than the raw pixels, it localizes the region the network used instead of scoring every pixel.\n\nThe two methods sit at opposite ends of a resolution trade-off: integrated gradients is fine-grained and pixel-level, Grad-CAM is coarse and region-level. Running both on the same image and noting where they agree, and where they do not, is the heart of this assignment.\n\nWe strongly advise PyTorch with [Captum](https://captum.ai/tutorials/) unless you already have Keras/TF expertise, because both methods ship as ready implementations there (`IntegratedGradients` and `LayerGradCam`). You are free to use the high-level APIs of the framework of your choice.\n\n### What to submit\n\nFor each method, in the cells below:\n\n- A markdown explanation written so that anyone who understands how a CNN works can follow it. Cover the intuition, the role of the baseline (integrated gradients) or the target layer (Grad-CAM), and one limitation of the method.\n- Working code that runs the explainer on at least three correctly classified images and at least one image the model got wrong.\n- The resulting maps overlaid on the input images, each with a one-line caption stating what the map suggests the model attended to.\n\n### How your work is evaluated\n\n- Correctness: the right baseline, the right target layer, and gradients taken with respect to the predicted class rather than a fixed label.\n- Visualization quality: maps are overlaid on the inputs, readable, and labeled.\n- Depth of interpretation: noting that a map \"looks reasonable\" is not enough. Point to where the two methods agree, where they disagree, and what the misclassified example tells you about what the model actually learned."
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/notebook-database.yml
+++ b/notebooks/notebook-database.yml
@@ -554,3 +554,8 @@ notebooks:
   code_cells: 12
   environment: torch.dev.gpu
   description: CTR prediction with logistic regression, the hashing trick and SGD
+- source: aiml-common/assignments/topics/cnn-explainers/index.ipynb
+  notebook: assignments/topics/cnn-explainers/index.ipynb
+  code_cells: 0
+  environment: torch.dev.gpu
+  description: "Explaining CNNs assignment: integrated gradients and Grad-CAM on cats vs dogs"


### PR DESCRIPTION
Automated notebook publish via `manage_notebooks.py`.

- Notebook: `assignments/topics/cnn-explainers/index.ipynb`
- Registry: `notebooks/notebook-database.yml`

PR self-merged because `main` is push-protected.